### PR TITLE
Brian/new feature - 2 edits/updates

### DIFF
--- a/client/components/Bids.jsx
+++ b/client/components/Bids.jsx
@@ -117,7 +117,8 @@ Different approach with a reset of form fields
                 type='file'
                 onChange={selectFile}
                 className='inputButton'
-                accept='application/*, image/*'
+                // accept='application/*, image/*'  // * wildcard didn't work - BMA
+                accept='.pdf, .doc, .docx, .xls, .xlsx, image/*' // changed from application/* to specific file types
                 required
               />
             </div>

--- a/client/components/Documents.jsx
+++ b/client/components/Documents.jsx
@@ -116,6 +116,9 @@ const getMimeType = (filename) => {
       return 'text/html';
     case 'csv':
       return 'text/csv';
+      // Added docx for Word docs, however it prompts to download.  Won't view in browser - BMA
+      case 'docx':
+        return 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
     default:
       return 'application/octet-stream'; // Default for unknown types
   }


### PR DESCRIPTION
1. Made a line edit in Documents.jsx to correct a file upload MIME/file type problem preventing uploading needed file types.
2. Line edit to Bids.jsx adding docx as a supported MIME type to allow downloading of Word docs.  On Firefox it won't view in browser requring file download instead. 

